### PR TITLE
Feat: Add strategy to filter by email domain

### DIFF
--- a/lib/unleash/strategy/email_from_domain.rb
+++ b/lib/unleash/strategy/email_from_domain.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Unleash
+  module Strategy
+    class EmailFromDomain < Base
+      def name
+        'emailFromDomain'
+      end
+
+      def is_enabled?(params = {}, context = nil)
+        params['domains'].include? domain(context)
+      end
+
+      private
+
+      def domain(context)
+        context&.properties&.values_at('email', :email)&.compact&.first&.split('@')&.last
+      end
+    end
+  end
+end

--- a/spec/unleash/strategy/email_from_domain_spec.rb
+++ b/spec/unleash/strategy/email_from_domain_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'unleash/context'
+
+RSpec.describe Unleash::Strategy::EmailFromDomain do
+  let(:unleash_context) { Unleash::Context.new(properties: { email: email }) }
+
+  describe '#is_enabled?' do
+    subject { described_class.new.is_enabled?({ 'domains' => ['active.com'] }, unleash_context) }
+
+    context 'when the email is blank' do
+      let(:email) { nil }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when the email is invalid' do
+      let(:email) { 'my.own' }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when the email is valid' do
+      context 'when the domain is not enabled' do
+        let(:email) { 'my@personal.net' }
+        it { is_expected.to be_falsey }
+      end
+
+      context 'when the domain is enabled' do
+        let(:email) { 'my@active.com' }
+        it { is_expected.to be_truthy }
+      end
+    end
+  end
+end

--- a/unleash-client-ruby-pipefy.gemspec
+++ b/unleash-client-ruby-pipefy.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'unleash-client-ruby-pipefy'
-  spec.version       = 1.5
+  spec.version       = 1.6
   spec.authors       = ['Anderson Campos, Gustavo Candido, Thais Caldeira']
   spec.email         = ['anderson.campos@pipefy.com, gustavo.candido@pipefy.com, thais.caldeira@pipefy.com']
 


### PR DESCRIPTION
This change adds the strategy to allow to toogle by a domain emails.

For example to enable to all `@outlook.com` user emails.

![development-RequestTrackerNotBotConfirmation-Feature-Toggles-Unleash](https://user-images.githubusercontent.com/54237/125644032-d5df7493-9fb1-4ef4-8d7b-8dcb2051060b.png)
