### PR TITLE
Fix: Bug on strategy to check for email domain 

### DIFF
--- a/lib/unleash/strategy/email_from_domain.rb
+++ b/lib/unleash/strategy/email_from_domain.rb
@@ -3,12 +3,18 @@
 module Unleash
   module Strategy
     class EmailFromDomain < Base
+      PARAM = 'domains'.freeze
+
       def name
         'emailFromDomain'
       end
 
       def is_enabled?(params = {}, context = nil)
-        params['domains'].include? domain(context)
+        return false unless params.is_a?(Hash) && params.has_key?(PARAM)
+        return false unless params.fetch(PARAM, nil).is_a? String
+        return false unless context.class.name == 'Unleash::Context'
+
+        params[PARAM].split(",").map(&:strip).include? domain(context)
       end
 
       private

--- a/spec/unleash/strategy/email_from_domain_spec.rb
+++ b/spec/unleash/strategy/email_from_domain_spec.rb
@@ -6,7 +6,13 @@ RSpec.describe Unleash::Strategy::EmailFromDomain do
   let(:unleash_context) { Unleash::Context.new(properties: { email: email }) }
 
   describe '#is_enabled?' do
-    subject { described_class.new.is_enabled?({ 'domains' => ['active.com'] }, unleash_context) }
+    subject { described_class.new.is_enabled?({ 'domains' => 'active.com,fake.com' }, unleash_context) }
+
+    context 'when there is not email properties' do
+      let(:unleash_context) { Unleash::Context.new(properties: { name: nil }) }
+
+      it { is_expected.to be_falsey }
+    end
 
     context 'when the email is blank' do
       let(:email) { nil }

--- a/unleash-client-ruby-pipefy.gemspec
+++ b/unleash-client-ruby-pipefy.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'unleash-client-ruby-pipefy'
-  spec.version       = 1.6
+  spec.version       = 1.7
   spec.authors       = ['Anderson Campos, Gustavo Candido, Thais Caldeira']
   spec.email         = ['anderson.campos@pipefy.com, gustavo.candido@pipefy.com, thais.caldeira@pipefy.com']
 


### PR DESCRIPTION
This change fix the error below, happens when check if a string includes a nil value.

```
no implicit conversion of nil into String
```
