### PR TITLE
Handle empty organization creation time

### DIFF
--- a/lib/unleash/strategy/org_created_after.rb
+++ b/lib/unleash/strategy/org_created_after.rb
@@ -15,9 +15,12 @@ module Unleash
         return false unless context.instance_of?(Unleash::Context)
         return false if forbidden_org_uuids(params).include?(current_org_uuid(context))
 
+        org_creation_date = org_created_at(context)
+        return false unless org_creation_date.present?
+
         begin
-          base_time = DateTime.parse(params[PARAM]) 
-          org_time = DateTime.parse(org_created_at(context))
+          base_time = DateTime.parse(params[PARAM])
+          org_time = DateTime.parse(org_creation_date)
         rescue ArgumentError
           return false
         end

--- a/lib/unleash/strategy/org_created_after.rb
+++ b/lib/unleash/strategy/org_created_after.rb
@@ -16,7 +16,7 @@ module Unleash
         return false if forbidden_org_uuids(params).include?(current_org_uuid(context))
 
         org_creation_date = org_created_at(context)
-        return false unless org_creation_date.present?
+        return false if org_creation_date.nil?
 
         begin
           base_time = DateTime.parse(params[PARAM])

--- a/spec/unleash/strategy/org_created_after_spec.rb
+++ b/spec/unleash/strategy/org_created_after_spec.rb
@@ -27,5 +27,15 @@ RSpec.describe Unleash::Strategy::OrgCreatedAfter do
 
       expect(strategy.is_enabled?(params, unleash_context)).to be_falsey
     end
+
+    context 'when the organization UUID is empty' do
+      let(:unleash_context) do
+        Unleash::Context.new({ properties: { org_uuid: '1234', 'org_created_at' => nil } })
+      end
+
+      it 'is disabled' do
+        expect(strategy.is_enabled?({ 'orgCreatedAfter' => '2021-01-01 00:00:00 UTC' }, unleash_context)).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
After enabling a feature that depends on the [org_created_after](https://github.com/pipefy/unleash-client-ruby-pipefy/blob/master/lib/unleash/strategy/org_created_after.rb) strategy, the public phase form started raising errors:

https://app.datadoghq.com/apm/service/pipefy-public/rack.request?env=production&hostGroup=%2A&topGraphs=latency%3Alatency_by_version%2Cerrors%3Aversion_count%2Chits%3Aversion_count%2CbreakdownAs%3Apercentage&start=1642003417854&end=1642006052000&paused=true

Following the traces, we pass the Unleash context in many places, and those places are using the `organization_for_login` which is supposed to be the organization that the user sees when she logins first, but it's used as the "current organization" which is a wrong usage for the method (that's a topic for another discussion).

This resulted in the public phase form breaking as it's sending this value as `nil` as there's no organization in this case.

In this MR, we handle the `nil` case by early returning.