### PR TITLE
fix: user created after breaking when the user creation date is nil

### DIFF
--- a/lib/unleash/strategy/user_created_after.rb
+++ b/lib/unleash/strategy/user_created_after.rb
@@ -15,12 +15,11 @@ module Unleash
         return false unless context.instance_of?(Unleash::Context)
         return false if forbidden_org_uuids(params).include?(current_org_uuid(context))
 
-        user_creation_date = user_created_at(context)
-+       return false if user_creation_date.nil?
+        user_creation_date = user_created_at(context).to_s
 
         begin
           base_time = DateTime.parse(params[PARAM])
-+         user_time = DateTime.parse(user_creation_date)
+          user_time = DateTime.parse(user_creation_date)
         rescue ArgumentError
           return false
         end

--- a/lib/unleash/strategy/user_created_after.rb
+++ b/lib/unleash/strategy/user_created_after.rb
@@ -15,9 +15,12 @@ module Unleash
         return false unless context.instance_of?(Unleash::Context)
         return false if forbidden_org_uuids(params).include?(current_org_uuid(context))
 
+        user_creation_date = user_created_at(context)
++       return false if user_creation_date.nil?
+
         begin
-          base_time = DateTime.parse(params[PARAM]) 
-          user_time = DateTime.parse(user_created_at(context))
+          base_time = DateTime.parse(params[PARAM])
++         user_time = DateTime.parse(user_creation_date)
         rescue ArgumentError
           return false
         end

--- a/spec/unleash/strategy/email_from_domain_spec.rb
+++ b/spec/unleash/strategy/email_from_domain_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'unleash/context'
+require 'unleash/strategy/email_from_domain'
 
 RSpec.describe Unleash::Strategy::EmailFromDomain do
   let(:unleash_context) { Unleash::Context.new(properties: { email: email }) }

--- a/spec/unleash/strategy/org_created_after_spec.rb
+++ b/spec/unleash/strategy/org_created_after_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'unleash/context'
+require 'unleash/strategy/org_created_after'
 
 RSpec.describe Unleash::Strategy::OrgCreatedAfter do
   describe '#is_enabled?' do

--- a/spec/unleash/strategy/org_with_uuid_spec.rb
+++ b/spec/unleash/strategy/org_with_uuid_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'unleash/context'
+require 'unleash/strategy/org_with_uuid'
 
 RSpec.describe Unleash::Strategy::OrgWithUUID do
   describe '#is_enabled?' do

--- a/spec/unleash/strategy/org_without_uuid_spec.rb
+++ b/spec/unleash/strategy/org_without_uuid_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'unleash/context'
+require 'unleash/strategy/org_without_uuid'
 
 RSpec.describe Unleash::Strategy::OrgWithoutUUID do
   describe '#is_enabled?' do

--- a/spec/unleash/strategy/pipe_with_uuid_spec.rb
+++ b/spec/unleash/strategy/pipe_with_uuid_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'unleash/context'
+require 'unleash/strategy/pipe_with_uuid'
 
 RSpec.describe Unleash::Strategy::PipeWithUUID do
   describe '#is_enabled?' do

--- a/spec/unleash/strategy/use_case_spec.rb
+++ b/spec/unleash/strategy/use_case_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'unleash/context'
+require 'unleash/strategy/use_case'
 
 RSpec.describe Unleash::Strategy::UseCase do
   describe '#is_enabled?' do

--- a/spec/unleash/strategy/user_created_after_spec.rb
+++ b/spec/unleash/strategy/user_created_after_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require 'unleash/context'
-require 'unleash/strategy/org_created_after'
+require 'unleash/strategy/user_created_after'
 
 RSpec.describe Unleash::Strategy::UserCreatedAfter do
   describe '#is_enabled?' do
-    let(:strategy) { Unleash::Strategy::UserCreatedAfter.new }
+    let(:strategy) { described_class.new }
     let(:unleash_context) do
       Unleash::Context.new({ properties: { org_uuid: '1234', 'user_created_at' => '2021-05-27 17:50:59 UTC' } })
     end

--- a/spec/unleash/strategy/user_created_after_spec.rb
+++ b/spec/unleash/strategy/user_created_after_spec.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 require 'unleash/context'
+require 'unleash/strategy/org_created_after'
 
 RSpec.describe Unleash::Strategy::UserCreatedAfter do
   describe '#is_enabled?' do
     let(:strategy) { Unleash::Strategy::UserCreatedAfter.new }
-    let(:unleash_context) { Unleash::Context.new({ properties: { org_uuid: '1234', 'user_created_at' => '2021-05-27 17:50:59 UTC' } }) }
+    let(:unleash_context) do
+      Unleash::Context.new({ properties: { org_uuid: '1234', 'user_created_at' => '2021-05-27 17:50:59 UTC' } })
+    end
 
     it 'should be enabled if user creation date is older then strategy set date' do
       expect(strategy.is_enabled?({ 'userCreatedAfter' => '2021-01-01 00:00:00 UTC' }, unleash_context)).to be_truthy
@@ -26,6 +29,16 @@ RSpec.describe Unleash::Strategy::UserCreatedAfter do
       }
 
       expect(strategy.is_enabled?(params, unleash_context)).to be_falsey
+    end
+
+    context 'when the user creation date is empty' do
+      let(:unleash_context) do
+        Unleash::Context.new({ properties: { org_uuid: '1234', 'user_created_at' => nil } })
+      end
+
+      it 'is disabled' do
+        expect(strategy.is_enabled?({ 'userCreatedAfter' => '2021-01-01 00:00:00 UTC' }, unleash_context)).to be false
+      end
     end
   end
 end

--- a/unleash-client-ruby-pipefy.gemspec
+++ b/unleash-client-ruby-pipefy.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'unleash-client-ruby-pipefy'
-  spec.version       = '2.1.0'
+  spec.version       = '2.1.1'
   spec.authors       = ['Anderson Campos, Gustavo Candido, Thais Caldeira']
   spec.email         = ['anderson.campos@pipefy.com, gustavo.candido@pipefy.com, thais.caldeira@pipefy.com']
 


### PR DESCRIPTION
# 🐞 The problem

We had an incident when using the userCreatedAfter strategy, as can be seen in this [slack thread](https://pipefy.slack.com/archives/GEY4N54LQ/p1684529970445339). It happened only in the public forms because the `user_created_at` parameter was null in this scenario, and the code was not prepared for this scenario.

# 💻 The fix

- Add validation for the user creation date

# 🗂 Related cards

[Fix the bug of the userCreatedAfter Unleash strategy](https://app.pipefy.com/open-cards/716329887) from [Activation - PLG pipe](https://app.pipefy.com/pipes/302207022)

# 📑 For the reviewer

- To be compliant with SOC and ISO policies, all MRs need to be associated with an open card, which must be linked to on their descriptions. Please, do not approve or merge MRs without a card link attached.

- Check out our [Guidelines for the Reviewer](https://git.pipefy.net/pipefy/guidelines/-/blob/master/docs/code-review/for-the-reviewer/README.md) to assist your review process.
